### PR TITLE
Fix report generation integrations

### DIFF
--- a/foampilot/src/foampilot/report/latex_pdf.py
+++ b/foampilot/src/foampilot/report/latex_pdf.py
@@ -290,9 +290,10 @@ class LatexDocument:
         """
         self.doc.preamble.append(NoEscape(command))
 
-    def generate_tex(self):
-        """Generates the .tex source file in the report directory."""
+    def generate_tex(self) -> Path:
+        """Generates the .tex source file and returns its path."""
         self.doc.generate_tex(str(self.filepath))
+        return self.filepath.with_suffix(".tex")
 
     def generate_pdf(self):
         """Compiles the .tex file into a PDF using pdflatex.

--- a/foampilot/src/foampilot/report/mesh_report.py
+++ b/foampilot/src/foampilot/report/mesh_report.py
@@ -1,5 +1,5 @@
-import re
 import logging
+import re
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -159,7 +159,10 @@ class MeshQualityReport:
                     self.mesh_stats["internal_faces"] / cc, 2
                 )
 
-        if "boundary_faces" in self.mesh_stats and "num_patches" in self.mesh_stats:
+        if (
+            "boundary_faces" in self.mesh_stats
+            and self.mesh_stats.get("num_patches", 0) > 0
+        ):
             self.quality_metrics["boundary_faces_per_patch"] = round(
                 self.mesh_stats["boundary_faces"] / self.mesh_stats["num_patches"], 2
             )

--- a/foampilot/src/foampilot/report/report_generator.py
+++ b/foampilot/src/foampilot/report/report_generator.py
@@ -10,7 +10,7 @@ import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
 from foampilot.report.latex_pdf import LatexDocument
-from foampilot.report.typst_pdf import ScientificDocument
+from foampilot.report.typst_pdf import ScientificDocument, TypstRenderer
 
 logger = logging.getLogger(__name__)
 
@@ -505,11 +505,14 @@ class CFDReportGenerator:
         Path
             Path to the generated ``.tex`` file (and PDF if ``compile_pdf=True``).
         """
+        output_name = Path(filename)
+        if output_name.suffix == ".tex":
+            output_name = output_name.with_suffix("")
         doc = LatexDocument(
             title=self.title,
             author=self.author,
-            filename=str(self.output_dir / filename).replace(".tex", ""),
-            output_dir=str(self.output_dir),
+            filename=str(output_name),
+            output_dir=str(self.output_dir.parent),
         )
         doc.add_abstract(
             f"CFD post-processing report for case: {self.case_path}"
@@ -582,9 +585,21 @@ class CFDReportGenerator:
                 ])
             doc.add_table(table_data, caption="Summary statistics", label="tab:statistics")
 
-        tex_content = doc.render(doc)
+        for index, tbl in enumerate(self._tables, start=1):
+            doc.add_table(
+                tbl["data"],
+                headers=tbl["headers"],
+                caption=tbl["caption"],
+                label=f"tab_{index}",
+            )
+
+        for fig in self._figures:
+            doc.add_figure(fig["path"], fig["caption"], label=fig["label"])
+
+        renderer = TypstRenderer()
+        typst_content = renderer.render(doc)
         out_path = self.output_dir / filename
-        with open(out_path, "w", encoding="utf-8") as f:
-            f.write(tex_content)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(typst_content, encoding="utf-8")
 
         return out_path

--- a/foampilot/src/foampilot/report/report_generator.py
+++ b/foampilot/src/foampilot/report/report_generator.py
@@ -364,11 +364,26 @@ class CFDReportGenerator:
         """
         if vectors not in mesh.point_data:
             raise ValueError(f"Vector field '{vectors}' not found in mesh point data.")
+        if not isinstance(subsample, int) or subsample < 1:
+            raise ValueError("subsample must be a positive integer.")
 
-        vecs = mesh.point_data[vectors]
-        points = mesh.points
+        vecs = np.asarray(mesh.point_data[vectors])
+        points = np.asarray(mesh.points)
         if vecs.ndim == 1:
+            if vecs.size % 3 != 0:
+                raise ValueError(
+                    f"Vector field '{vectors}' must contain 3 components per point."
+                )
             vecs = vecs.reshape(-1, 3)
+        if vecs.ndim != 2 or vecs.shape[1] != 3:
+            raise ValueError(
+                f"Vector field '{vectors}' must have shape (n_points, 3)."
+            )
+        if len(points) != len(vecs):
+            raise ValueError(
+                f"Vector field '{vectors}' has {len(vecs)} values for "
+                f"{len(points)} mesh points."
+            )
 
         xs, ys, zs = points[::subsample].T
         u, v, w = vecs[::subsample].T

--- a/foampilot/src/foampilot/report/report_generator.py
+++ b/foampilot/src/foampilot/report/report_generator.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pyvista as pv
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
+from plotly.offline import get_plotlyjs
 
 from foampilot.report.latex_pdf import LatexDocument
 from foampilot.report.typst_pdf import ScientificDocument, TypstRenderer
@@ -50,6 +51,7 @@ class CFDReportGenerator:
         self._statistics: Dict[str, Any] = {}
         self._figures: List[Dict[str, str]] = []
         self._tables: List[Dict[str, Any]] = []
+        self._plotly_figures: List[Dict[str, Any]] = []
 
     def add_statistic(
         self, name: str, value: Any, unit: str = "", description: str = ""
@@ -104,6 +106,35 @@ class CFDReportGenerator:
         self._tables.append(
             {"data": data, "headers": headers, "caption": caption}
         )
+
+    def add_plotly_figure(
+        self, figure: go.Figure, caption: str = "", kind: str = "figure"
+    ) -> None:
+        """Register an interactive Plotly figure for HTML output.
+
+        Parameters
+        ----------
+        figure : plotly.graph_objects.Figure
+            Figure to embed in the generated HTML.
+        caption : str, optional
+            Human-readable figure caption.
+        kind : str, optional
+            Figure category. Use ``"time_series"`` for figures controlled by
+            :paramref:`save_html_report.include_time_series`.
+        """
+        if not isinstance(figure, go.Figure):
+            raise TypeError("figure must be a plotly.graph_objects.Figure")
+        self._plotly_figures.append(
+            {"figure": figure, "caption": caption, "kind": kind}
+        )
+
+    def add_time_series(
+        self, df: pd.DataFrame, scalar_field: str, title: str = ""
+    ) -> go.Figure:
+        """Create and register a scalar time-series figure for HTML output."""
+        figure = self.generate_plotly_time_series(df, scalar_field, title)
+        self.add_plotly_figure(figure, title or scalar_field, kind="time_series")
+        return figure
 
     def collect_time_series(
         self, postprocessor: "FoamPostProcessing", scalar_field: str
@@ -421,6 +452,9 @@ class CFDReportGenerator:
     ) -> Path:
         """Generate a self-contained interactive HTML report.
 
+        Plotly JavaScript is embedded inline when interactive figures are present;
+        the resulting file does not require network access to render those figures.
+
         Parameters
         ----------
         filename : str or Path, optional
@@ -443,9 +477,13 @@ class CFDReportGenerator:
         escaped_author = html.escape(str(self.author), quote=True)
         escaped_case = html.escape(str(self.case_path), quote=True)
         html_parts.append(f"<title>{escaped_title}</title>")
-        html_parts.append(
-            "<script src='https://cdn.plot.ly/plotly-2.32.0.min.js'></script>"
-        )
+        visible_plotly_figures = [
+            item
+            for item in self._plotly_figures
+            if include_time_series or item["kind"] != "time_series"
+        ]
+        if visible_plotly_figures:
+            html_parts.append(f"<script>{get_plotlyjs()}</script>")
         html_parts.append(
             "<style>"
             "body { font-family: sans-serif; margin: 2em; max-width: 1200px; }"
@@ -486,6 +524,23 @@ class CFDReportGenerator:
                 html_parts.append(f"<h3>{caption}</h3>")
                 html_parts.append(f'<img src="{path}" alt="{caption}" style="max-width:100%;">')
                 html_parts.append(f'</div>')
+
+        # Interactive Plotly figures
+        if visible_plotly_figures:
+            html_parts.append("<h2>Interactive Figures</h2>")
+            for index, item in enumerate(visible_plotly_figures, start=1):
+                caption = html.escape(str(item["caption"]))
+                html_parts.append(f'<div class="figure-container" id="plotly-{index}">')
+                if caption:
+                    html_parts.append(f"<h3>{caption}</h3>")
+                html_parts.append(
+                    item["figure"].to_html(
+                        full_html=False,
+                        include_plotlyjs=False,
+                        config={"responsive": True},
+                    )
+                )
+                html_parts.append("</div>")
 
         # Tables
         if self._tables:

--- a/foampilot/src/foampilot/report/report_generator.py
+++ b/foampilot/src/foampilot/report/report_generator.py
@@ -1,4 +1,5 @@
 import json
+import html
 import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
@@ -435,10 +436,13 @@ class CFDReportGenerator:
         html_parts: List[str] = []
 
         html_parts.append("<!DOCTYPE html>")
-        html_parts.append('<html lang="en">')
+        html_parts.append('<html lang="fr">')
         html_parts.append("<head>")
         html_parts.append("<meta charset='utf-8'>")
-        html_parts.append(f"<title>{self.title}</title>")
+        escaped_title = html.escape(str(self.title), quote=True)
+        escaped_author = html.escape(str(self.author), quote=True)
+        escaped_case = html.escape(str(self.case_path), quote=True)
+        html_parts.append(f"<title>{escaped_title}</title>")
         html_parts.append(
             "<script src='https://cdn.plot.ly/plotly-2.32.0.min.js'></script>"
         )
@@ -455,9 +459,9 @@ class CFDReportGenerator:
         )
         html_parts.append("</head>")
         html_parts.append("<body>")
-        html_parts.append(f"<h1>{self.title}</h1>")
-        html_parts.append(f"<p><strong>Author:</strong> {self.author}</p>")
-        html_parts.append(f"<p><strong>Case:</strong> {self.case_path}</p>")
+        html_parts.append(f"<h1>{escaped_title}</h1>")
+        html_parts.append(f"<p><strong>Author:</strong> {escaped_author}</p>")
+        html_parts.append(f"<p><strong>Case:</strong> {escaped_case}</p>")
 
         # Statistics summary
         if self._statistics:
@@ -465,8 +469,10 @@ class CFDReportGenerator:
             html_parts.append("<table><tr><th>Parameter</th><th>Value</th><th>Unit</th><th>Description</th></tr>")
             for name, stat in self._statistics.items():
                 html_parts.append(
-                    f"<tr><td>{name}</td><td>{stat['value']}</td>"
-                    f"<td>{stat['unit']}</td><td>{stat['description']}</td></tr>"
+                    f"<tr><td>{html.escape(str(name))}</td>"
+                    f"<td>{html.escape(str(stat['value']))}</td>"
+                    f"<td>{html.escape(str(stat['unit']))}</td>"
+                    f"<td>{html.escape(str(stat['description']))}</td></tr>"
                 )
             html_parts.append("</table>")
 
@@ -475,25 +481,39 @@ class CFDReportGenerator:
             html_parts.append("<h2>Figures</h2>")
             for fig in self._figures:
                 html_parts.append(f'<div class="figure-container">')
-                html_parts.append(f'<h3>{fig["caption"]}</h3>')
-                html_parts.append(f'<img src="{fig["path"]}" alt="{fig["caption"]}" style="max-width:100%;">')
+                caption = html.escape(str(fig["caption"]), quote=True)
+                path = html.escape(str(fig["path"]), quote=True)
+                html_parts.append(f"<h3>{caption}</h3>")
+                html_parts.append(f'<img src="{path}" alt="{caption}" style="max-width:100%;">')
                 html_parts.append(f'</div>')
 
         # Tables
         if self._tables:
             html_parts.append("<h2>Tables</h2>")
             for tbl in self._tables:
-                html_parts.append(f'<h3>{tbl["caption"]}</h3>')
+                html_parts.append(f"<h3>{html.escape(str(tbl['caption']))}</h3>")
                 html_parts.append("<table>")
-                html_parts.append("<tr>" + "".join(f"<th>{h}</th>" for h in tbl["headers"]) + "</tr>")
+                html_parts.append(
+                    "<tr>"
+                    + "".join(
+                        f"<th>{html.escape(str(header))}</th>"
+                        for header in tbl["headers"]
+                    )
+                    + "</tr>"
+                )
                 for row in tbl["data"]:
-                    html_parts.append("<tr>" + "".join(f"<td>{c}</td>" for c in row) + "</tr>")
+                    html_parts.append(
+                        "<tr>"
+                        + "".join(f"<td>{html.escape(str(cell))}</td>" for cell in row)
+                        + "</tr>"
+                    )
                 html_parts.append("</table>")
 
         html_parts.append("</body>")
         html_parts.append("</html>")
 
         out_path = self.output_dir / filename
+        out_path.parent.mkdir(parents=True, exist_ok=True)
         with open(out_path, "w", encoding="utf-8") as f:
             f.write("\n".join(html_parts))
 

--- a/foampilot/src/foampilot/report/simulation_report.py
+++ b/foampilot/src/foampilot/report/simulation_report.py
@@ -85,6 +85,17 @@ class SimulationReport:
             logger.warning("No log file found for case: %s", self.case_dir)
             return
 
+        self.residual_data = defaultdict(
+            lambda: {"time": [], "initial": [], "final": [], "iterations": []}
+        )
+        self.warnings.clear()
+        self.errors.clear()
+        self.execution_time = 0.0
+        self.clock_time = 0
+        self.iteration_count = 0
+        self.courant_mean = 0.0
+        self.courant_max = 0.0
+
         time_pattern = re.compile(r"Time = (\d+\.?\d*)s?")
         solver_pattern = re.compile(
             r"(smoothSolver|GAMG|PCG|PBiCGStab|geometricOneWire):\s+"

--- a/foampilot/src/foampilot/report/simulation_report.py
+++ b/foampilot/src/foampilot/report/simulation_report.py
@@ -576,8 +576,8 @@ class SimulationReport:
         self._extract_warnings_errors()
         self._extract_mesh_stats_from_log()
         self._extract_mesh_stats_from_polyMesh()
-        self._extract_solver_settings()
-        self._extract_bc_summary()
+        self.solver_settings = self._extract_solver_settings()
+        self.bc_summary = self._extract_bc_summary()
 
         final_residuals = self._extract_final_residuals()
         convergence = self._compute_convergence_metrics()

--- a/foampilot/src/foampilot/report/typst_pdf.py
+++ b/foampilot/src/foampilot/report/typst_pdf.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Optional, Dict, Any, Union
 import typst
+import shutil
 import subprocess
 
 # ============================================================
@@ -173,31 +174,32 @@ class TypstRenderer:
         return f'#figure({block}, caption: [{typst_escape(c.caption)}])' if c.caption else block
 
 
-    def compile_pdf(self, doc: ScientificDocument, output_pdf: str = "report/rapport_complet.pdf"):
-        """
-        Génère un fichier .typ et compile le PDF via le binaire Typst (subprocess).
-        Compatible Ubuntu + Snap.
-        """
-        Path("report").mkdir(exist_ok=True)
-        typ_file = Path("report/rapport_complet.typ")
-        # Rendu Typst
-        source = self.render(doc)
-        typ_file.write_text(source, encoding="utf-8")
+    def compile_pdf(
+        self,
+        doc: ScientificDocument,
+        output_pdf: str = "report/rapport_complet.pdf",
+    ) -> Path:
+        """Render ``doc`` and compile it with the first available Typst binary."""
+        output_path = Path(output_pdf)
+        if not output_path.is_absolute():
+            output_path = Path.cwd() / output_path
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        typ_file = output_path.with_suffix(".typ")
+        typ_file.write_text(self.render(doc), encoding="utf-8")
 
-        # Chemin vers le binaire Typst
-        typst_bin = "/snap/bin/typst"  # Modifie si nécessaire
-
-        # Compilation via subprocess
-        try:
-            subprocess.run(
-                [typst_bin, "compile", str(typ_file), output_pdf],  # <-- sortie en second argument
-                check=True
+        typst_bin = shutil.which("typst") or (
+            "/snap/bin/typst" if Path("/snap/bin/typst").exists() else None
+        )
+        if typst_bin is None:
+            raise FileNotFoundError(
+                "Typst executable not found; install Typst or add it to PATH."
             )
-            print(f"PDF généré avec succès : {output_pdf}")
-        except subprocess.CalledProcessError as e:
-            print("Erreur lors de la compilation Typst :", e)
-        except FileNotFoundError:
-            print(f"Binaire Typst introuvable. Vérifie le chemin : {typst_bin}")
+
+        subprocess.run(
+            [typst_bin, "compile", str(typ_file), str(output_path)],
+            check=True,
+        )
+        return output_path
 
 
 

--- a/foampilot/test/test_report.py
+++ b/foampilot/test/test_report.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+from foampilot.report import CFDReportGenerator, SimulationReport
+
+
+def test_simulation_report_keeps_extracted_settings(tmp_path, monkeypatch):
+    log_path = tmp_path / "log.simpleFoam"
+    log_path.write_text(
+        "Time = 1\n"
+        "smoothSolver:  Solving for U, Initial residual = 1, Final residual = 1e-5, No Iterations 2\n"
+        "ExecutionTime = 0.5 s  ClockTime = 1 s\n"
+        "End\n",
+        encoding="utf-8",
+    )
+
+    report = SimulationReport(tmp_path)
+    monkeypatch.setattr(
+        report, "_extract_solver_settings", lambda: {"application": "simpleFoam"}
+    )
+    monkeypatch.setattr(
+        report, "_extract_bc_summary", lambda: {"inlet": {"type": "fixedValue"}}
+    )
+
+    content = report.generate_report()
+
+    assert report.solver_settings == {"application": "simpleFoam"}
+    assert report.bc_summary == {"inlet": {"type": "fixedValue"}}
+    assert "simpleFoam" in content
+    assert "fixedValue" in content
+
+
+def test_typst_report_renders_registered_content(tmp_path):
+    generator = CFDReportGenerator(tmp_path)
+    generator.add_statistic("Re", 1000, "-", "Reynolds number")
+    generator.add_table([[1, 2]], ["A", "B"], "Results")
+    generator.add_figure("mesh.png", "Mesh", label="fig_mesh")
+
+    output = generator.save_typst_report()
+    content = output.read_text(encoding="utf-8")
+
+    assert output == tmp_path / "report" / "cfd_report.typ"
+    assert "Reynolds number" in content
+    assert "Results" in content
+    assert "mesh.png" in content
+
+
+def test_latex_report_returns_generated_path(tmp_path):
+    generator = CFDReportGenerator(tmp_path)
+    output = generator.save_latex_report()
+
+    assert isinstance(output, Path)
+    assert output == tmp_path / "report" / "cfd_report.tex"
+    assert output.exists()

--- a/foampilot/test/test_report.py
+++ b/foampilot/test/test_report.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pandas as pd
+
 from foampilot.report import CFDReportGenerator, SimulationReport
 
 
@@ -111,3 +113,38 @@ def test_simulation_report_generation_is_idempotent(tmp_path):
     second_count = len(report.residual_data["U"]["final"])
 
     assert first_count == second_count == 1
+
+
+def test_html_report_embeds_plotly_and_filters_time_series(tmp_path):
+    import plotly.graph_objects as go
+
+    generator = CFDReportGenerator(tmp_path)
+    generator.add_plotly_figure(
+        go.Figure(data=go.Scatter(x=[0, 1], y=[1, 2])),
+        caption="General figure",
+    )
+    generator.add_time_series(
+        pd.DataFrame(
+            {
+                "time": [0, 1],
+                "p_mean": [1.0, 2.0],
+                "p_max": [1.5, 2.5],
+                "p_min": [0.5, 1.5],
+            }
+        ),
+        "p",
+        title="Pressure history",
+    )
+
+    without_series = generator.save_html_report(
+        filename="without-series.html", include_time_series=False
+    ).read_text(encoding="utf-8")
+    with_series = generator.save_html_report(
+        filename="with-series.html", include_time_series=True
+    ).read_text(encoding="utf-8")
+
+    assert "https://cdn.plot.ly" not in with_series
+    assert without_series.count("Plotly.newPlot") == 1
+    assert "Pressure history" not in without_series
+    assert "Pressure history" in with_series
+    assert with_series.count("Plotly.newPlot") == 2

--- a/foampilot/test/test_report.py
+++ b/foampilot/test/test_report.py
@@ -51,3 +51,33 @@ def test_latex_report_returns_generated_path(tmp_path):
     assert isinstance(output, Path)
     assert output == tmp_path / "report" / "cfd_report.tex"
     assert output.exists()
+
+
+def test_mesh_quality_report_handles_log_without_re_or_patches(tmp_path):
+    from foampilot.report.mesh_report import MeshQualityReport
+
+    (tmp_path / "log.blockMesh").write_text(
+        "Number of boundary faces: 4\n", encoding="utf-8"
+    )
+    report = MeshQualityReport(tmp_path)
+
+    content = report.generate_report()
+
+    assert "Mesh Quality Report" in content
+    assert "boundary_faces_per_patch" not in content
+
+
+def test_vector_plot_rejects_invalid_subsample(tmp_path):
+    import numpy as np
+    import pyvista as pv
+
+    generator = CFDReportGenerator(tmp_path)
+    mesh = pv.PolyData(np.zeros((2, 3)))
+    mesh.point_data["U"] = np.zeros((2, 3))
+
+    try:
+        generator.generate_plotly_vector_plot(mesh, "U", subsample=0)
+    except ValueError as exc:
+        assert "positive integer" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for a non-positive subsample")

--- a/foampilot/test/test_report.py
+++ b/foampilot/test/test_report.py
@@ -81,3 +81,33 @@ def test_vector_plot_rejects_invalid_subsample(tmp_path):
         assert "positive integer" in str(exc)
     else:
         raise AssertionError("Expected ValueError for a non-positive subsample")
+
+
+def test_html_report_escapes_user_content(tmp_path):
+    generator = CFDReportGenerator(tmp_path, title="<unsafe>", author='A & B')
+    generator.add_statistic("<Re>", "<1>", "&", "quoted <value>")
+
+    output = generator.save_html_report()
+    content = output.read_text(encoding="utf-8")
+
+    assert "&lt;unsafe&gt;" in content
+    assert "&lt;Re&gt;" in content
+    assert "&lt;1&gt;" in content
+    assert "<unsafe>" not in content
+
+
+def test_simulation_report_generation_is_idempotent(tmp_path):
+    log_path = tmp_path / "log.simpleFoam"
+    log_path.write_text(
+        "Time = 1\n"
+        "smoothSolver: Solving for U, Initial residual = 1, Final residual = 1e-5, No Iterations 2\n",
+        encoding="utf-8",
+    )
+    report = SimulationReport(tmp_path)
+
+    report.generate_report()
+    first_count = len(report.residual_data["U"]["final"])
+    report.generate_report()
+    second_count = len(report.residual_data["U"]["final"])
+
+    assert first_count == second_count == 1


### PR DESCRIPTION
## Summary

- preserve extracted solver settings and boundary-condition summaries in `SimulationReport`
- make repeated `generate_report()` calls idempotent
- render Typst reports through `TypstRenderer` and include registered tables and figures
- make Typst compilation portable, create parent directories, and propagate failures
- return the generated LaTeX source path and avoid nested `report/report` output paths
- escape user-controlled HTML content and create nested HTML output directories
- validate vector dimensions and positive subsampling factors
- guard mesh quality metrics against division by zero
- add `add_plotly_figure()` and `add_time_series()` APIs
- make `include_time_series` filter registered time-series figures
- embed Plotly JavaScript inline so generated HTML works without CDN/network access
- add regression tests for the integrations and edge cases

## Validation

- `python3 -m compileall -q src/foampilot/report test/test_report.py`
- `git diff main...HEAD --check`
- Targeted pytest collection is blocked in the sandbox by additional project dependencies required by the package import chain, including `build123d`; the tests are included for the project CI environment.